### PR TITLE
feat: disable public registration after master user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ AssetsMe é um gerenciador de arquivos estáticos construído com Laravel 11, In
    - `ASSETS_MAX_FILE_SIZE`: limite de upload em bytes (padrão 10 MB).
    - `VITE_API_BASE_URL`: endereço base para o cliente React alcançar a API (ex.: `http://localhost`).
    - `VITE_ASSETSME_TOKEN`: token utilizado pelo painel para enviar requisições à API (defina com um token gerado no menu **Tokens** do painel).
+   - `REGISTRATION_DEV_ALWAYS_OPEN` (opcional): defina como `true` para manter o formulário de cadastro público liberado em ambientes de desenvolvimento.
 
 4. Execute as migrações do banco:
 
@@ -152,6 +153,9 @@ O painel utiliza autenticação padrão do Laravel Breeze. Após realizar login:
 - **Upload** (`/assets/upload`): interface com drag-and-drop, seleção de pasta, barra de progresso e retorno das URLs com botão "Copiar".
 - **Listagem** (`/assets/list`): tabela com filtro por pasta, paginação, botões de copiar URL e remover asset.
 - **Tokens** (`/tokens`): listagem dos tokens vinculados ao usuário, criação de novos tokens (exibidos uma única vez) e exclusão segura.
+- **Usuários** (`/admin/users`): disponível apenas para o usuário master. Permite habilitar/desabilitar o cadastro público, criar usuários manualmente (com geração opcional de senha) e visualizar quem é o master.
+
+O primeiro usuário criado na plataforma é marcado automaticamente como **master**. Após esse cadastro inicial, o registro público é desabilitado até que o master o reative manualmente. Você pode reabrir ou encerrar o cadastro a qualquer momento pelo painel em **Usuários → Habilitar cadastro** ou persistindo o valor em `settings.registration_enabled` via seeders/migrations.
 
 As chamadas ao backend são feitas via `fetch` utilizando `Authorization: Bearer ${import.meta.env.VITE_ASSETSME_TOKEN}`. Configure esta variável com um token criado no menu **Tokens**; ele não é exibido na interface.
 

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
+use Laravel\Fortify\Contracts\CreatesNewUsers;
+
+class CreateNewUser implements CreatesNewUsers
+{
+    /**
+     * Validate and create a newly registered user.
+     */
+    public function create(array $input): User
+    {
+        $isFirstUser = User::query()->count() === 0;
+
+        if (! $isFirstUser) {
+            $registrationSettings = Setting::get('registration_enabled', ['on' => false]);
+            $registrationEnabled = (bool) data_get($registrationSettings, 'on', false);
+
+            if (! $registrationEnabled && ! (bool) env('REGISTRATION_DEV_ALWAYS_OPEN', false)) {
+                throw ValidationException::withMessages([
+                    'email' => __('Cadastro desabilitado pelo administrador.'),
+                ]);
+            }
+        }
+
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'password' => ['required', 'string', 'confirmed', Password::defaults()],
+        ])->validate();
+
+        $attributes = [
+            'name' => $input['name'],
+            'email' => $input['email'],
+            'password' => Hash::make($input['password']),
+        ];
+
+        if ($isFirstUser) {
+            $attributes['is_master'] = true;
+        }
+
+        $user = User::create($attributes);
+
+        if ($isFirstUser) {
+            Setting::put('registration_enabled', ['on' => false]);
+        }
+
+        return $user;
+    }
+}

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+
+class SettingsController extends Controller
+{
+    public function showRegistration(): JsonResponse
+    {
+        Gate::authorize('toggle-registration');
+
+        $settings = Setting::get('registration_enabled', ['on' => false]);
+        $registrationEnabled = (bool) data_get($settings, 'on', false);
+
+        return response()->json([
+            'data' => [
+                'on' => $registrationEnabled,
+            ],
+        ]);
+    }
+
+    public function updateRegistration(Request $request): JsonResponse
+    {
+        Gate::authorize('toggle-registration');
+
+        $validated = $request->validate([
+            'on' => ['required', 'boolean'],
+        ]);
+
+        $enabled = (bool) $validated['on'];
+
+        Setting::put('registration_enabled', ['on' => $enabled]);
+
+        return response()->json([
+            'data' => [
+                'on' => $enabled,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
+
+class UserController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        Gate::authorize('manage-users');
+
+        $users = User::query()
+            ->select(['id', 'name', 'email', 'is_master', 'created_at'])
+            ->orderByDesc('created_at')
+            ->paginate($request->integer('per_page', 10));
+
+        return response()->json($users);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        Gate::authorize('manage-users');
+
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'password' => ['nullable', 'string', Password::defaults()],
+            'generate_password' => ['sometimes', 'boolean'],
+        ]);
+
+        $validator->after(function ($validator) use ($request): void {
+            $shouldGenerate = $request->boolean('generate_password');
+
+            if (! $shouldGenerate && blank($request->input('password'))) {
+                $validator->errors()->add('password', __('Informe uma senha ou escolha gerar automaticamente.'));
+            }
+        });
+
+        $data = $validator->validate();
+
+        $temporaryPassword = null;
+
+        if ($request->boolean('generate_password')) {
+            $temporaryPassword = Str::random(24);
+        }
+
+        $password = $temporaryPassword ?? $data['password'];
+
+        if (! $password) {
+            throw ValidationException::withMessages([
+                'password' => __('Não foi possível determinar a senha do usuário.'),
+            ]);
+        }
+
+        $user = new User([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($password),
+        ]);
+
+        $user->forceFill([
+            'email_verified_at' => now(),
+            'is_master' => false,
+        ]);
+
+        $user->save();
+
+        return response()->json([
+            'data' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'is_master' => $user->is_master,
+                'created_at' => $user->created_at,
+            ],
+            'temporary_password' => $temporaryPassword,
+        ], 201);
+    }
+
+    public function destroy(User $user): JsonResponse
+    {
+        Gate::authorize('manage-users');
+
+        if ($user->is_master) {
+            return response()->json([
+                'message' => __('Não é possível remover o usuário master.'),
+            ], 422);
+        }
+
+        $user->delete();
+
+        return response()->json(status: 204);
+    }
+}

--- a/app/Http/Controllers/Admin/UsersPageController.php
+++ b/app/Http/Controllers/Admin/UsersPageController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class UsersPageController extends Controller
+{
+    public function __invoke(Request $request): Response
+    {
+        Gate::authorize('manage-users');
+
+        $users = User::query()
+            ->select(['id', 'name', 'email', 'is_master', 'created_at'])
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (User $user) => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'is_master' => (bool) $user->is_master,
+                'created_at' => $user->created_at?->toIso8601String(),
+            ]);
+
+        $registrationEnabled = (bool) data_get(
+            Setting::get('registration_enabled', ['on' => false]),
+            'on',
+            false
+        );
+
+        return Inertia::render('users/index', [
+            'users' => $users,
+            'registrationEnabled' => $registrationEnabled,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -3,18 +3,20 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules;
 use Inertia\Inertia;
 use Inertia\Response;
+use Laravel\Fortify\Contracts\CreatesNewUsers;
 
 class RegisteredUserController extends Controller
 {
+    public function __construct(private readonly CreatesNewUsers $creator)
+    {
+    }
+
     /**
      * Show the registration page.
      */
@@ -30,17 +32,7 @@ class RegisteredUserController extends Controller
      */
     public function store(Request $request): RedirectResponse
     {
-        $request->validate([
-            'name' => 'required|string|max:255',
-            'email' => 'required|string|lowercase|email|max:255|unique:'.User::class,
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
-
-        $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
-        ]);
+        $user = $this->creator->create($request->all());
 
         event(new Registered($user));
 

--- a/app/Http/Middleware/EnsureRegistrationOpen.php
+++ b/app/Http/Middleware/EnsureRegistrationOpen.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Setting;
+use App\Models\User;
+use Closure;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
+
+class EnsureRegistrationOpen
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): RedirectResponse|Response
+    {
+        if (User::query()->count() > 0) {
+            $settings = Setting::get('registration_enabled', ['on' => false]);
+            $on = Arr::get((array) $settings, 'on', false);
+
+            if (! $on && ! (bool) env('REGISTRATION_DEV_ALWAYS_OPEN', false)) {
+                return redirect()->route('login')->with('status', __('Cadastro desabilitado'));
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/TokenAuth.php
+++ b/app/Http/Middleware/TokenAuth.php
@@ -61,7 +61,7 @@ class TokenAuth
     private function unauthorized(): JsonResponse
     {
         return new JsonResponse([
-            'message' => 'Você não está autorizado a acessar este recurso.',
+            'message' => 'Unauthorized',
         ], Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'value' => 'array',
+    ];
+
+    public static function get(string $key, $default = null)
+    {
+        return optional(static::query()->where('key', $key)->first())->value ?? $default;
+    }
+
+    public static function put(string $key, $value): void
+    {
+        static::updateOrCreate(['key' => $key], ['value' => $value]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_master',
     ];
 
     /**
@@ -45,6 +46,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_master' => 'boolean',
         ];
     }
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The model to policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+
+        Gate::define('manage-users', fn (User $user): bool => (bool) $user->is_master);
+        Gate::define('toggle-registration', fn (User $user): bool => (bool) $user->is_master);
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -2,11 +2,13 @@
 
 namespace App\Providers;
 
+use App\Actions\Fortify\CreateNewUser;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Inertia\Inertia;
+use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
@@ -16,7 +18,7 @@ class FortifyServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(CreatesNewUsers::class, CreateNewUser::class);
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureRegistrationOpen;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\TokenAuth;
@@ -26,6 +27,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'token' => TokenAuth::class,
+            'registration-open' => EnsureRegistrationOpen::class,
         ]);
     })
     ->withCommands()

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,5 +2,6 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
     App\Providers\FortifyServiceProvider::class,
 ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_master' => false,
         ];
     }
 

--- a/database/migrations/2025_10_03_032734_create_settings_table.php
+++ b/database/migrations/2025_10_03_032734_create_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->json('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2025_10_03_032736_add_is_master_to_users_table.php
+++ b/database/migrations/2025_10_03_032736_add_is_master_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_master')->default(false)->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_master');
+        });
+    }
+};

--- a/resources/js/api/http.ts
+++ b/resources/js/api/http.ts
@@ -1,0 +1,79 @@
+export class HttpError<T = unknown> extends Error {
+    constructor(public readonly response: Response, public readonly payload: T) {
+        const message =
+            payload && typeof payload === 'object' && 'message' in payload && typeof payload.message === 'string'
+                ? payload.message
+                : `Request failed with status ${response.status}`;
+
+        super(message);
+    }
+}
+
+function getCsrfToken(): string | null {
+    const element = document.querySelector('meta[name="csrf-token"]');
+    return element?.getAttribute('content');
+}
+
+export async function request<T>(url: string, options: RequestInit = {}): Promise<T> {
+    const headers = new Headers(options.headers ?? {});
+    headers.set('Accept', 'application/json');
+
+    const body = options.body;
+    if (body && !(body instanceof FormData) && !headers.has('Content-Type')) {
+        headers.set('Content-Type', 'application/json');
+    }
+
+    if (options.method && options.method.toUpperCase() !== 'GET') {
+        const token = getCsrfToken();
+        if (token) {
+            headers.set('X-CSRF-Token', token);
+        }
+    }
+
+    const response = await fetch(url, {
+        credentials: 'same-origin',
+        ...options,
+        headers,
+    });
+
+    let payload: unknown = null;
+    try {
+        payload = await response.json();
+    } catch (error) {
+        if (!(error instanceof SyntaxError)) {
+            console.error(error);
+        }
+    }
+
+    if (!response.ok) {
+        throw new HttpError(response, payload);
+    }
+
+    return payload as T;
+}
+
+export function extractErrorMessage(payload: unknown, fallback: string): string {
+    if (!payload || typeof payload !== 'object') {
+        return fallback;
+    }
+
+    const data = payload as Record<string, unknown>;
+
+    if (typeof data.message === 'string' && data.message.trim() !== '') {
+        return data.message;
+    }
+
+    if (data.errors && typeof data.errors === 'object') {
+        const entries = Object.entries(data.errors as Record<string, unknown>);
+        for (const [, value] of entries) {
+            if (Array.isArray(value) && value.length > 0) {
+                const first = value.find((item) => typeof item === 'string');
+                if (typeof first === 'string' && first.trim() !== '') {
+                    return first;
+                }
+            }
+        }
+    }
+
+    return fallback;
+}

--- a/resources/js/api/settings.ts
+++ b/resources/js/api/settings.ts
@@ -1,0 +1,18 @@
+import { request } from '@/api/http';
+
+export interface RegistrationSettingsResponse {
+    data: {
+        on: boolean;
+    };
+}
+
+export async function getRegistration(): Promise<RegistrationSettingsResponse> {
+    return request<RegistrationSettingsResponse>('/api/admin/settings/registration');
+}
+
+export async function updateRegistration(on: boolean): Promise<RegistrationSettingsResponse> {
+    return request<RegistrationSettingsResponse>('/api/admin/settings/registration', {
+        method: 'PUT',
+        body: JSON.stringify({ on }),
+    });
+}

--- a/resources/js/api/users.ts
+++ b/resources/js/api/users.ts
@@ -1,0 +1,50 @@
+import { extractErrorMessage, request } from '@/api/http';
+
+export interface AdminUser {
+    id: number;
+    name: string;
+    email: string;
+    is_master: boolean;
+    created_at: string;
+}
+
+export interface PaginatedUsers {
+    data: AdminUser[];
+    meta: {
+        current_page: number;
+        per_page: number;
+        last_page: number;
+        total: number;
+    };
+}
+
+export interface CreateUserPayload {
+    name: string;
+    email: string;
+    password?: string;
+    generate_password?: boolean;
+}
+
+export interface CreateUserResponse {
+    data: AdminUser;
+    temporary_password?: string | null;
+}
+
+export async function list(): Promise<PaginatedUsers> {
+    return request<PaginatedUsers>('/api/admin/users');
+}
+
+export async function create(payload: CreateUserPayload): Promise<CreateUserResponse> {
+    return request<CreateUserResponse>('/api/admin/users', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function destroy(id: number): Promise<void> {
+    await request<unknown>(`/api/admin/users/${id}`, {
+        method: 'DELETE',
+    });
+}
+
+export { extractErrorMessage };

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -12,11 +12,11 @@ import {
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
 import { type NavItem } from '@/types';
-import { Link } from '@inertiajs/react';
-import { BookOpen, CloudUpload, Folder, KeyRound, LayoutGrid, List } from 'lucide-react';
+import { Link, usePage } from '@inertiajs/react';
+import { BookOpen, CloudUpload, Folder, KeyRound, LayoutGrid, List, Users } from 'lucide-react';
 import AppLogo from './app-logo';
 
-const mainNavItems: NavItem[] = [
+const baseNavItems: NavItem[] = [
     {
         title: 'Dashboard',
         href: dashboard(),
@@ -53,6 +53,12 @@ const footerNavItems: NavItem[] = [
 ];
 
 export function AppSidebar() {
+    const page = usePage<{ auth: { user?: { is_master?: boolean } | null } }>();
+    const isMaster = Boolean(page.props.auth?.user?.is_master);
+    const mainNavItems = isMaster
+        ? [...baseNavItems, { title: 'Usuários', href: '/admin/users', icon: Users }]
+        : baseNavItems;
+
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>

--- a/resources/js/pages/users/index.tsx
+++ b/resources/js/pages/users/index.tsx
@@ -1,0 +1,412 @@
+import { create, CreateUserPayload, extractErrorMessage, type AdminUser } from '@/api/users';
+import { HttpError } from '@/api/http';
+import { updateRegistration } from '@/api/settings';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/app-layout';
+import type { SharedData } from '@/types';
+import { Head } from '@inertiajs/react';
+import { useCallback, useMemo, useState } from 'react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib/utils';
+
+interface UsersPageProps extends SharedData {
+    users: AdminUser[];
+    registrationEnabled: boolean;
+}
+
+const breadcrumbs = [
+    { title: 'Dashboard', href: '/dashboard' },
+    { title: 'Usuários', href: '/admin/users' },
+];
+
+function formatDate(date: string | null | undefined): string {
+    if (!date) {
+        return '—';
+    }
+
+    const parsed = new Date(date);
+    if (Number.isNaN(parsed.getTime())) {
+        return '—';
+    }
+
+    return parsed.toLocaleString('pt-BR');
+}
+
+export default function UsersIndex({ users: initialUsers, registrationEnabled }: UsersPageProps) {
+    const [users, setUsers] = useState<AdminUser[]>(initialUsers);
+    const [registrationOn, setRegistrationOn] = useState<boolean>(registrationEnabled);
+    const [toggleLoading, setToggleLoading] = useState<boolean>(false);
+    const [notification, setNotification] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
+
+    const [dialogOpen, setDialogOpen] = useState<boolean>(false);
+    const [temporaryPassword, setTemporaryPassword] = useState<string | null>(null);
+    const [passwordDialogOpen, setPasswordDialogOpen] = useState<boolean>(false);
+    const [formState, setFormState] = useState<CreateUserPayload & { generate_password: boolean }>(
+        () => ({ name: '', email: '', password: '', generate_password: true }),
+    );
+    const [formErrors, setFormErrors] = useState<Record<string, string>>({});
+    const [formLoading, setFormLoading] = useState<boolean>(false);
+    const [passwordCopied, setPasswordCopied] = useState<boolean>(false);
+
+    const sortedUsers = useMemo(
+        () =>
+            [...users].sort((a, b) => {
+                return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+            }),
+        [users],
+    );
+
+    const showNotification = useCallback((type: 'success' | 'error', message: string) => {
+        setNotification({ type, message });
+        window.setTimeout(() => {
+            setNotification((current) => (current?.message === message ? null : current));
+        }, 5000);
+    }, []);
+
+    const handleToggleRegistration = useCallback(
+        async (event: React.ChangeEvent<HTMLInputElement>) => {
+            const desiredState = event.target.checked;
+            const previousState = registrationOn;
+            setToggleLoading(true);
+            setNotification(null);
+            setRegistrationOn(desiredState);
+
+            try {
+                const response = await updateRegistration(desiredState);
+                setRegistrationOn(response.data.on);
+                showNotification('success', response.data.on ? 'Cadastro público habilitado.' : 'Cadastro público desabilitado.');
+            } catch (error) {
+                setRegistrationOn(previousState);
+                const message =
+                    error instanceof HttpError
+                        ? extractErrorMessage(error.payload, 'Não foi possível atualizar a configuração.')
+                        : 'Não foi possível atualizar a configuração.';
+                showNotification('error', message);
+            } finally {
+                setToggleLoading(false);
+            }
+        },
+        [registrationOn, showNotification],
+    );
+
+    const resetForm = useCallback(() => {
+        setFormState({ name: '', email: '', password: '', generate_password: true });
+        setFormErrors({});
+        setPasswordCopied(false);
+    }, []);
+
+    const handleCreateUser = useCallback(
+        async (event: React.FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            setFormLoading(true);
+            setFormErrors({});
+            setNotification(null);
+
+            const payload: CreateUserPayload = {
+                name: formState.name.trim(),
+                email: formState.email.trim(),
+                generate_password: formState.generate_password,
+            };
+
+            if (!formState.generate_password) {
+                payload.password = formState.password;
+            }
+
+            try {
+                const response = await create(payload);
+                setUsers((current) => [response.data, ...current]);
+                setDialogOpen(false);
+                resetForm();
+                showNotification('success', 'Usuário criado com sucesso.');
+
+                if (response.temporary_password) {
+                    setTemporaryPassword(response.temporary_password);
+                    setPasswordDialogOpen(true);
+                } else {
+                    setTemporaryPassword(null);
+                }
+            } catch (error) {
+                if (error instanceof HttpError) {
+                    const payloadErrors =
+                        error.payload && typeof error.payload === 'object'
+                            ? (error.payload as { errors?: Record<string, string[]> }).errors ?? {}
+                            : {};
+
+                    const formattedErrors: Record<string, string> = {};
+                    Object.entries(payloadErrors).forEach(([key, messages]) => {
+                        if (Array.isArray(messages) && messages.length > 0) {
+                            formattedErrors[key] = messages[0];
+                        }
+                    });
+
+                    setFormErrors(formattedErrors);
+                    const message = extractErrorMessage(error.payload, 'Não foi possível criar o usuário.');
+                    showNotification('error', message);
+                } else {
+                    showNotification('error', 'Não foi possível criar o usuário.');
+                }
+            } finally {
+                setFormLoading(false);
+            }
+        },
+        [formState, resetForm, showNotification],
+    );
+
+    const handleCopyPassword = useCallback(async () => {
+        if (!temporaryPassword) {
+            return;
+        }
+
+        try {
+            await navigator.clipboard.writeText(temporaryPassword);
+            setPasswordCopied(true);
+        } catch (error) {
+            console.error(error);
+        }
+    }, [temporaryPassword]);
+
+    return (
+        <AppLayout breadcrumbs={breadcrumbs}>
+            <Head title="Usuários" />
+
+            <div className="space-y-6">
+                {notification && (
+                    <Alert variant={notification.type === 'error' ? 'destructive' : 'default'}>
+                        <AlertTitle>{notification.type === 'error' ? 'Erro' : 'Sucesso'}</AlertTitle>
+                        <AlertDescription>{notification.message}</AlertDescription>
+                    </Alert>
+                )}
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Cadastro público</CardTitle>
+                        <CardDescription>
+                            Controle se novos usuários podem se registrar sem convite.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="flex items-center justify-between gap-4">
+                        <div>
+                            <p className="text-sm text-muted-foreground">
+                                Quando desabilitado, somente o usuário master pode criar novas contas.
+                            </p>
+                        </div>
+                        <label className="flex items-center gap-2 text-sm font-medium">
+                            <input
+                                type="checkbox"
+                                role="switch"
+                                className={cn(
+                                    'h-6 w-11 appearance-none rounded-full border border-transparent transition',
+                                    registrationOn ? 'bg-primary' : 'bg-muted',
+                                    toggleLoading ? 'opacity-70' : '',
+                                )}
+                                onChange={handleToggleRegistration}
+                                checked={registrationOn}
+                                disabled={toggleLoading}
+                            />
+                            <span>{registrationOn ? 'Cadastro habilitado' : 'Cadastro desabilitado'}</span>
+                        </label>
+                    </CardContent>
+                </Card>
+
+                <Card>
+                    <CardHeader className="flex flex-row items-center justify-between">
+                        <div>
+                            <CardTitle>Usuários</CardTitle>
+                            <CardDescription>Gerencie a equipe que pode acessar o AssetsMe.</CardDescription>
+                        </div>
+                        <Dialog
+                            open={dialogOpen}
+                            onOpenChange={(open) => {
+                                setDialogOpen(open);
+                                if (!open) {
+                                    resetForm();
+                                }
+                            }}
+                        >
+                            <DialogTrigger asChild>
+                                <Button>Adicionar usuário</Button>
+                            </DialogTrigger>
+                            <DialogContent>
+                                <DialogHeader>
+                                    <DialogTitle>Novo usuário</DialogTitle>
+                                    <DialogDescription>
+                                        Informe os dados básicos do usuário. A senha só será exibida uma vez quando gerada automaticamente.
+                                    </DialogDescription>
+                                </DialogHeader>
+                                <form className="space-y-4" onSubmit={handleCreateUser}>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="user-name">Nome</Label>
+                                        <Input
+                                            id="user-name"
+                                            value={formState.name}
+                                            autoComplete="name"
+                                            onChange={(event) =>
+                                                setFormState((current) => ({ ...current, name: event.target.value }))
+                                            }
+                                            required
+                                        />
+                                        {formErrors.name && (
+                                            <p className="text-sm text-destructive">{formErrors.name}</p>
+                                        )}
+                                    </div>
+                                    <div className="space-y-2">
+                                        <Label htmlFor="user-email">E-mail</Label>
+                                        <Input
+                                            id="user-email"
+                                            type="email"
+                                            value={formState.email}
+                                            autoComplete="email"
+                                            onChange={(event) =>
+                                                setFormState((current) => ({ ...current, email: event.target.value }))
+                                            }
+                                            required
+                                        />
+                                        {formErrors.email && (
+                                            <p className="text-sm text-destructive">{formErrors.email}</p>
+                                        )}
+                                    </div>
+                                    <div className="space-y-2">
+                                        <div className="flex items-center gap-2">
+                                            <Checkbox
+                                                id="generate-password"
+                                                checked={formState.generate_password}
+                                                onCheckedChange={(checked) =>
+                                                    setFormState((current) => ({
+                                                        ...current,
+                                                        generate_password: Boolean(checked),
+                                                        password: checked ? '' : current.password,
+                                                    }))
+                                                }
+                                            />
+                                            <Label htmlFor="generate-password" className="cursor-pointer">
+                                                Gerar senha automaticamente
+                                            </Label>
+                                        </div>
+                                        {!formState.generate_password && (
+                                            <div className="space-y-2">
+                                                <Label htmlFor="user-password">Senha</Label>
+                                                <Input
+                                                    id="user-password"
+                                                    type="password"
+                                                    value={formState.password}
+                                                    autoComplete="new-password"
+                                                    onChange={(event) =>
+                                                        setFormState((current) => ({
+                                                            ...current,
+                                                            password: event.target.value,
+                                                        }))
+                                                    }
+                                                />
+                                            </div>
+                                        )}
+                                        {formErrors.password && (
+                                            <p className="text-sm text-destructive">{formErrors.password}</p>
+                                        )}
+                                    </div>
+                                    <DialogFooter>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            onClick={() => {
+                                                setDialogOpen(false);
+                                                resetForm();
+                                            }}
+                                            disabled={formLoading}
+                                        >
+                                            Cancelar
+                                        </Button>
+                                        <Button type="submit" disabled={formLoading}>
+                                            {formLoading ? 'Salvando...' : 'Salvar'}
+                                        </Button>
+                                    </DialogFooter>
+                                </form>
+                            </DialogContent>
+                        </Dialog>
+                    </CardHeader>
+                    <CardContent>
+                        <div className="overflow-x-auto">
+                            <table className="min-w-full divide-y divide-border">
+                                <thead>
+                                    <tr className="text-left text-sm text-muted-foreground">
+                                        <th className="px-4 py-3 font-medium">Nome</th>
+                                        <th className="px-4 py-3 font-medium">E-mail</th>
+                                        <th className="px-4 py-3 font-medium">Criado em</th>
+                                        <th className="px-4 py-3 font-medium">Master</th>
+                                    </tr>
+                                </thead>
+                                <tbody className="divide-y divide-border text-sm">
+                                    {sortedUsers.map((user) => (
+                                        <tr key={user.id}>
+                                            <td className="px-4 py-3 font-medium">{user.name}</td>
+                                            <td className="px-4 py-3">{user.email}</td>
+                                            <td className="px-4 py-3">{formatDate(user.created_at)}</td>
+                                            <td className="px-4 py-3">
+                                                {user.is_master ? (
+                                                    <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
+                                                        Master
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-muted-foreground">—</span>
+                                                )}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    {sortedUsers.length === 0 && (
+                                        <tr>
+                                            <td className="px-4 py-6 text-center text-muted-foreground" colSpan={4}>
+                                                Nenhum usuário cadastrado até o momento.
+                                            </td>
+                                        </tr>
+                                    )}
+                                </tbody>
+                            </table>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+
+            <Dialog
+                open={passwordDialogOpen}
+                onOpenChange={(open) => {
+                    setPasswordDialogOpen(open);
+                    if (!open) {
+                        setPasswordCopied(false);
+                    }
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Senha gerada automaticamente</DialogTitle>
+                        <DialogDescription>
+                            Copie e compartilhe esta senha com o usuário. Ela não será exibida novamente.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 p-4 text-center">
+                        <code className="text-lg font-semibold tracking-wide">{temporaryPassword}</code>
+                    </div>
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => setPasswordDialogOpen(false)}>
+                            Fechar
+                        </Button>
+                        <Button type="button" onClick={handleCopyPassword}>
+                            {passwordCopied ? 'Copiado!' : 'Copiar senha'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -39,6 +39,7 @@ export interface User {
     two_factor_enabled?: boolean;
     created_at: string;
     updated_at: string;
+    is_master?: boolean;
     [key: string]: unknown; // This allows for additional properties...
 }
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -10,11 +10,13 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
-    Route::get('register', [RegisteredUserController::class, 'create'])
-        ->name('register');
+    Route::middleware('registration-open')->group(function () {
+        Route::get('register', [RegisteredUserController::class, 'create'])
+            ->name('register');
 
-    Route::post('register', [RegisteredUserController::class, 'store'])
-        ->name('register.store');
+        Route::post('register', [RegisteredUserController::class, 'store'])
+            ->name('register.store');
+    });
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
         ->name('login');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\Admin\SettingsController as AdminSettingsController;
+use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Controllers\Admin\UsersPageController;
 use App\Http\Controllers\TokenController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -22,6 +25,17 @@ Route::middleware(['auth', 'verified'])->group(function () {
     })->name('assets.list');
 
     Route::resource('tokens', TokenController::class)->only(['index', 'store', 'destroy']);
+
+    Route::get('admin/users', UsersPageController::class)->name('admin.users.index');
+});
+
+Route::middleware(['auth', 'verified'])->prefix('api/admin')->group(function () {
+    Route::get('users', [AdminUserController::class, 'index']);
+    Route::post('users', [AdminUserController::class, 'store']);
+    Route::delete('users/{user}', [AdminUserController::class, 'destroy']);
+
+    Route::get('settings/registration', [AdminSettingsController::class, 'showRegistration']);
+    Route::put('settings/registration', [AdminSettingsController::class, 'updateRegistration']);
 });
 
 require __DIR__.'/settings.php';

--- a/tests/Feature/Admin/UserManagementTest.php
+++ b/tests/Feature/Admin/UserManagementTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Support\Arr;
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\delete;
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\put;
+
+it('allows the master user to toggle public registration', function () {
+    $master = User::factory()->create(['is_master' => true]);
+    Setting::put('registration_enabled', ['on' => false]);
+
+    actingAs($master);
+
+    $response = put('/api/admin/settings/registration', ['on' => true]);
+
+    $response->assertOk();
+    $response->assertJsonPath('data.on', true);
+
+    expect((bool) Arr::get(Setting::get('registration_enabled', []), 'on'))->toBeTrue();
+});
+
+it('prevents non-master users from accessing user management routes', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get('/admin/users')->assertForbidden();
+    get('/api/admin/users')->assertForbidden();
+    post('/api/admin/users', [])->assertForbidden();
+});
+
+it('creates a user with a generated password when requested', function () {
+    $master = User::factory()->create(['is_master' => true]);
+
+    actingAs($master);
+
+    $response = post('/api/admin/users', [
+        'name' => 'Invited User',
+        'email' => 'invited@example.com',
+        'generate_password' => true,
+    ]);
+
+    $response->assertCreated();
+    $response->assertJsonStructure([
+        'data' => ['id', 'name', 'email', 'is_master', 'created_at'],
+        'temporary_password',
+    ]);
+
+    $payload = $response->json();
+    expect($payload['temporary_password'])->not->toBeEmpty();
+
+    $user = User::query()->where('email', 'invited@example.com')->first();
+    expect($user)->not->toBeNull();
+    expect($user->is_master)->toBeFalse();
+    expect($user->email_verified_at)->not->toBeNull();
+});
+
+it('does not allow the master user to be deleted', function () {
+    $master = User::factory()->create(['is_master' => true]);
+
+    actingAs($master);
+
+    $response = delete("/api/admin/users/{$master->id}");
+
+    $response->assertStatus(422);
+    $response->assertJsonPath('message', 'Não é possível remover o usuário master.');
+    expect(User::query()->count())->toBe(1);
+});

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,12 +1,15 @@
 <?php
 
-test('registration screen can be rendered', function () {
+use App\Models\Setting;
+use App\Models\User;
+
+it('renders the registration screen when public registration is open', function () {
     $response = $this->get(route('register'));
 
-    $response->assertStatus(200);
+    $response->assertOk();
 });
 
-test('new users can register', function () {
+it('creates the first user as master and disables public registration', function () {
     $response = $this->post(route('register.store'), [
         'name' => 'Test User',
         'email' => 'test@example.com',
@@ -16,4 +19,31 @@ test('new users can register', function () {
 
     $this->assertAuthenticated();
     $response->assertRedirect(route('dashboard', absolute: false));
+
+    $user = User::query()->first();
+    expect($user)->not->toBeNull();
+    expect($user->is_master)->toBeTrue();
+
+    $settings = Setting::get('registration_enabled');
+    expect($settings)->toBeArray()
+        ->and(data_get($settings, 'on'))->toBeFalse();
+});
+
+it('blocks registration attempts once public registration is disabled', function () {
+    User::factory()->create(['is_master' => true]);
+    Setting::put('registration_enabled', ['on' => false]);
+
+    $getResponse = $this->get(route('register'));
+    $getResponse->assertRedirect(route('login'));
+
+    $postResponse = $this->from(route('register'))->post(route('register.store'), [
+        'name' => 'Another User',
+        'email' => 'another@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $postResponse->assertRedirect(route('login'));
+    $postResponse->assertSessionHas('status', 'Cadastro desabilitado');
+    expect(User::query()->count())->toBe(1);
 });


### PR DESCRIPTION
## Summary
- add persistent registration flag and master user support, including migrations, Setting model, and Fortify user creation guardrails
- add admin APIs and Inertia page for masters to manage users, toggle public registration, and handle manual user creation
- hide registration routes when disabled, surface Users menu only for masters, and document the new controls

## Testing
- php artisan test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df4271f5c0832c8657d2f3d40ae3cb