### PR TITLE
Use L5-Swagger for API docs, move spec; add robust asset delete and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,21 @@ qualquer verificação de token.
 Todas as rotas ficam sob `/api` e exigem um token válido (veja "Tokens fixos"). Utilize `Authorization: Bearer $TOKEN`,
 `X-AssetsMe-Token: $TOKEN` ou o query param `?token=$TOKEN`, exceto no health check.
 
+## Swagger (API Docs)
+
+O projeto utiliza a biblioteca **L5-Swagger** para expor a documentação da API via interface Swagger UI.
+
+- Acesse em: `http://localhost:8000/api/documentation`
+- O arquivo OpenAPI é servido a partir de `storage/api-docs/swagger.json`
+
+### Autenticação no Swagger
+
+Clique em **Authorize** e informe o token no formato:
+
+```
+Bearer SEU_TOKEN
+```
+
 ### Health check
 
 ```http

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.2",
         "inertiajs/inertia-laravel": "^2.0",
         "intervention/image": "^2.7",
+        "darkaonline/l5-swagger": "^8.6",
         "laravel/fortify": "^1.30",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+    'default' => 'default',
+
+    'defaults' => [
+        'routes' => [
+            'api' => 'api/documentation',
+            'docs' => 'docs',
+            'oauth2_callback' => 'api/oauth2-callback',
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+        ],
+
+        'paths' => [
+            'docs_json' => 'swagger.json',
+            'docs_yaml' => 'swagger.yaml',
+            'format_to_use_for_docs' => 'json',
+            'docs' => storage_path('api-docs'),
+            'annotations' => [
+                base_path('app'),
+            ],
+        ],
+
+        'scanOptions' => [
+            'analyser' => null,
+            'analysis' => null,
+            'processors' => [],
+            'pattern' => null,
+            'exclude' => [],
+            'open_api_spec_version' => '3.0.0',
+        ],
+
+        'generate_always' => false,
+        'generate_yaml_copy' => false,
+        'proxy' => false,
+        'additional_config_url' => null,
+        'operations_sort' => null,
+        'validator_url' => null,
+        'constants' => [],
+    ],
+];

--- a/resources/js/api/library.ts
+++ b/resources/js/api/library.ts
@@ -146,3 +146,14 @@ export async function renameAsset(payload: RenameAssetPayload): Promise<RenameAs
         body: JSON.stringify(payload),
     });
 }
+
+export interface DeleteAssetPayload {
+    path: string;
+}
+
+export async function deleteAsset(payload: DeleteAssetPayload): Promise<{ deleted: boolean }> {
+    const query = new URLSearchParams({ path: payload.path });
+    return request<{ deleted: boolean }>(`/api/assets/file?${query.toString()}`, {
+        method: 'DELETE',
+    });
+}

--- a/resources/js/components/library/assets-list.tsx
+++ b/resources/js/components/library/assets-list.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { RenameAssetDialog } from './rename-asset-dialog';
+import { DeleteAssetDialog } from './delete-asset-dialog';
 
 const root = (import.meta.env.VITE_API_URL as string | undefined) ?? window.location.origin;
 const assetsBase = `${root}/assets/`;
@@ -76,6 +77,7 @@ export function AssetsList({ assets, folderId, previewAssetIds = [] }: AssetsLis
     const { toast } = useToast();
     const queryClient = useQueryClient();
     const [renameAsset, setRenameAsset] = useState<LibraryAsset | null>(null);
+    const [deleteAsset, setDeleteAsset] = useState<LibraryAsset | null>(null);
 
     const togglePreviewMutation = useMutation({
         mutationFn: async ({ assetId }: { assetId: number | string }) => {
@@ -155,7 +157,7 @@ export function AssetsList({ assets, folderId, previewAssetIds = [] }: AssetsLis
                                                 <Pencil className="h-4 w-4 mr-2" />
                                                 Renomear
                                             </DropdownMenuItem>
-                                            <DropdownMenuItem disabled className="text-muted-foreground">
+                                            <DropdownMenuItem onClick={() => setDeleteAsset(asset)} className="text-red-600">
                                                 <Trash2 className="h-4 w-4 mr-2" />
                                                 Deletar
                                             </DropdownMenuItem>
@@ -217,6 +219,13 @@ export function AssetsList({ assets, folderId, previewAssetIds = [] }: AssetsLis
                     asset={renameAsset}
                     open={!!renameAsset}
                     onOpenChange={(open) => !open && setRenameAsset(null)}
+                />
+            )}
+            {deleteAsset && (
+                <DeleteAssetDialog
+                    asset={deleteAsset}
+                    open={!!deleteAsset}
+                    onOpenChange={(open) => !open && setDeleteAsset(null)}
                 />
             )}
         </div>

--- a/resources/js/components/library/delete-asset-dialog.tsx
+++ b/resources/js/components/library/delete-asset-dialog.tsx
@@ -1,0 +1,59 @@
+import { deleteAsset } from '@/api/library';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { useToast } from '@/hooks/use-toast';
+import type { LibraryAsset } from '@/types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface DeleteAssetDialogProps {
+    asset: LibraryAsset;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteAssetDialog({ asset, open, onOpenChange }: DeleteAssetDialogProps) {
+    const queryClient = useQueryClient();
+    const { toast } = useToast();
+    const fileName = asset.path.split('/').pop();
+
+    const mutation = useMutation({
+        mutationFn: async () => {
+            return await deleteAsset({ path: asset.path });
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['library'] }).catch(() => null);
+            toast({
+                title: 'Arquivo excluído',
+                description: fileName ? `"${fileName}" foi removido.` : 'O arquivo foi removido.',
+                variant: 'success',
+            });
+            onOpenChange(false);
+        },
+        onError: () => {
+            toast({ title: 'Não foi possível excluir o arquivo', variant: 'destructive' });
+        },
+    });
+
+    return (
+        <Dialog open={open} onOpenChange={(state) => !mutation.isPending && onOpenChange(state)}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Excluir arquivo</DialogTitle>
+                    <DialogDescription>
+                        {fileName
+                            ? `Deseja excluir definitivamente "${fileName}"? Esta ação não pode ser desfeita.`
+                            : 'Deseja excluir definitivamente este arquivo? Esta ação não pode ser desfeita.'}
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)} disabled={mutation.isPending}>
+                        Cancelar
+                    </Button>
+                    <Button variant="destructive" onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+                        {mutation.isPending ? 'Excluindo…' : 'Excluir'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/storage/api-docs/swagger.json
+++ b/storage/api-docs/swagger.json
@@ -1,0 +1,260 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "AssetsMe API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8000"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "paths": {
+    "/api/health": {
+      "get": {
+        "summary": "Health check",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/upload": {
+      "post": {
+        "summary": "Upload assets",
+        "parameters": [
+          {
+            "name": "folder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "small",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "medium",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "large",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files[]": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "binary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upload result"
+          },
+          "422": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/list": {
+      "get": {
+        "summary": "List assets",
+        "parameters": [
+          {
+            "name": "folder",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list"
+          }
+        }
+      }
+    },
+    "/api/assets/file": {
+      "delete": {
+        "summary": "Delete asset",
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "deleted": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Asset not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/assets/rename": {
+      "patch": {
+        "summary": "Rename asset",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": ["path", "name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Renamed asset"
+          },
+          "404": {
+            "description": "Asset not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Replace the ad-hoc public Swagger files with the community `L5-Swagger` integration so the API docs are served via a proper Laravel package and support configured auth.
- Ensure asset deletion removes any generated thumbnails and surfaces structured server errors when deletion fails.  
- Provide a client-side confirmation dialog to safely delete assets from the admin UI.

### Description

- Add `config/l5-swagger.php`, add the `darkaonline/l5-swagger` requirement to `composer.json`, move the OpenAPI spec to `storage/api-docs/swagger.json`, and remove the static `public/swagger.*` files; document access and how to `Authorize` in `README.md`.
- Update `app/Http/Controllers/AssetController.php` `delete` handler to collect `generated_thumbs`, delete them together with the original file via the storage disk, and wrap the operation in a `try/catch` that returns a JSON `500` response on failure.
- Add a frontend API `deleteAsset` in `resources/js/api/library.ts`, a `DeleteAssetDialog` component at `resources/js/components/library/delete-asset-dialog.tsx`, and wire it into `resources/js/components/library/assets-list.tsx` so the UI shows a confirmation and invalidates the `['library']` query on success.

### Testing

- No automated tests were executed for these changes.
- No automated test failures were reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964767aaaa8832ca083e51e304a6413)